### PR TITLE
Fix inventory state synchronization

### DIFF
--- a/gameScene.js
+++ b/gameScene.js
@@ -73,11 +73,7 @@ export class GameScene extends Phaser.Scene {
         this.cardSystem = new CardSystem(this);
         this.inventorySystem = new InventorySystem(this, this.gameState.inventory);
         console.log('InventorySystem created:', this.inventorySystem);
-        
-        // After this.inventorySystem = new InventorySystem(...)
-        this.inventorySystem.slots = this.gameState.inventory || new Array(5).fill(null); // Load from state if exists
-        this.gameState.inventory = this.inventorySystem.slots; // Sync back
-        
+
         this.inventorySystem.setVisibility(true); // Ensure shown on start
         
         // Create UI
@@ -106,16 +102,9 @@ export class GameScene extends Phaser.Scene {
             console.log('Current inventory:', this.inventorySystem?.slots);
             console.log('GameState inventory:', this.gameState.inventory);
             
-            // Force inventory sync on wake
-            if (this.inventorySystem) {
-                this.inventorySystem.slots = this.gameState.inventory || this.inventorySystem.slots;
-                this.gameState.inventory = this.inventorySystem.slots;
-                this.inventorySystem.rebuildInventorySprites(); // Redraw UI
-            }
-            
             this.roomType = this.gameState.roomType || 'COMBAT';
             console.log('GameScene wake roomType:', this.roomType);
-            
+
             if (this.inventorySystem) {
                 console.log('Waking inventory - forcing visibility true');
                 this.inventorySystem.setVisibility(true);
@@ -348,11 +337,6 @@ export class GameScene extends Phaser.Scene {
     }
 
     updateUI() {
-        // Force sync inventory EVERY time UI updates
-        if (this.inventorySystem) {
-            this.gameState.inventory = [...(this.inventorySystem.slots || [])];
-        }
-
         const rawHealth = this.gameState.playerHealth ?? 0;
         const rawMaxHealth = this.gameState.maxHealth ?? 0;
         this.healthText.setText(`HP: ${rawHealth}/${rawMaxHealth}`);

--- a/gameState.js
+++ b/gameState.js
@@ -16,7 +16,11 @@ export class GameState {
         this.currentFloor = 1;
         this.equippedArmor = null;
         this.equippedWeapon = null;
-        this.inventory = new Array(5).fill(null);
+        this.bonusInventorySlots = 0; // For Bottomless Bag
+
+        const baseSlots = 5;
+        const totalSlots = baseSlots + this.bonusInventorySlots;
+        this.inventory = new Array(totalSlots).fill(null);
 
         // Room/route tracking
         this.roomType = 'COMBAT';
@@ -33,7 +37,6 @@ export class GameState {
 
         // Amulet-related properties
         this.firstActionUsed = false; // For Speed Boots
-        this.bonusInventorySlots = 0; // For Bottomless Bag
         this.baseMaxHealth = 50; // Store base max health for cursed amulets
         this.bottomlessBagApplied = false;
 
@@ -66,16 +69,10 @@ export class GameState {
 
     nextFloor() {
         this.currentFloor++;
-        
-        // Make sure inventory syncs from the actual inventory system
-        const gameScene = this.scene.scene.get('GameScene');
-        if (gameScene && gameScene.inventorySystem) {
-            this.inventory = [...gameScene.inventorySystem.slots]; // Create a copy
-        }
-        
+
         this.blockNextAttack = false;
         this.firstActionUsed = false;
-        
+
         if (this.scene.amuletManager) {
             this.scene.amuletManager.processFloorEnd();
         }

--- a/inventorySystem.js
+++ b/inventorySystem.js
@@ -2,24 +2,30 @@ import { SoundHelper } from './utils/SoundHelper.js';
 export class InventorySystem {
     constructor(scene, existingInventory = null) {
         this.scene = scene;
-        
+
         // Check for Bottomless Bag bonus slots
         const baseSlots = 5;
         const bonusSlots = this.scene.gameState.bonusInventorySlots || 0;
         const totalSlots = baseSlots + bonusSlots;
-        
-        // Initialize slots array with proper size
-        this.slots = new Array(totalSlots).fill(null);
-        
-        // If we have existing inventory, copy it properly
-        if (existingInventory && Array.isArray(existingInventory)) {
-            existingInventory.forEach((item, i) => {
+
+        // Ensure gameState.inventory is properly initialized
+        if (!this.scene.gameState.inventory || this.scene.gameState.inventory.length !== totalSlots) {
+            const oldInventory = this.scene.gameState.inventory || existingInventory || [];
+            this.scene.gameState.inventory = new Array(totalSlots).fill(null);
+            // Copy old items to new array
+            oldInventory.forEach((item, i) => {
                 if (i < totalSlots && item) {
-                    this.slots[i] = item;
+                    this.scene.gameState.inventory[i] = item;
                 }
             });
         }
-        
+
+        // Create getter/setter for slots that uses gameState
+        Object.defineProperty(this, 'slots', {
+            get: () => this.scene.gameState.inventory,
+            set: (value) => { this.scene.gameState.inventory = value; }
+        });
+
         this.slotSprites = [];
         this.discardArea = null;
         this.uiGroup = this.scene.add.group();


### PR DESCRIPTION
## Summary
- use the shared `GameState.inventory` as the single source of truth for the inventory system
- remove manual inventory copies during scene wake and UI updates to prevent desyncs
- initialize the inventory array from bonus slots and simplify floor transitions

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ddc0697cdc832492ad6eeadb89ba3a