### PR TITLE
Fix inventory synchronization, floor indexing, and scene listener leaks

### DIFF
--- a/cardSystem.js
+++ b/cardSystem.js
@@ -1688,7 +1688,7 @@ export class CardSystem {
         const splashSprite = this.scene.add.sprite(x, y, 'splash1');
         splashSprite.setScale(1.5); // Adjust size if needed
         splashSprite.play('splash_anim');
-        
+
         // On complete: Destroy sprite, add loot
         splashSprite.on('animationcomplete', () => {
             splashSprite.destroy();
@@ -1697,5 +1697,59 @@ export class CardSystem {
             this.scene.gameState.crystals += 5;
             this.scene.createFloatingText(x, y - 20, '+20 Coins +5 Crystals!', 0xffd700);
         });
+    }
+
+    cleanup() {
+        this.boardCards.forEach(card => {
+            if (!card) {
+                return;
+            }
+
+            const sprite = card.sprite;
+            if (sprite && !sprite.destroyed) {
+                if (sprite.off) {
+                    sprite.off('pointerdown');
+                    sprite.off('pointerover');
+                    sprite.off('pointerout');
+                }
+                if (sprite.removeInteractive) {
+                    sprite.removeInteractive();
+                }
+                sprite.destroy();
+            }
+
+            if (card.shadow) {
+                card.shadow.destroy();
+                card.shadow = null;
+            }
+
+            if (card.glow) {
+                card.glow.destroy();
+                card.glow = null;
+            }
+
+            if (card.highlight) {
+                card.highlight.destroy();
+                card.highlight = null;
+            }
+
+            if (card.infoText) {
+                if (card.infoText.list) {
+                    card.infoText.list.forEach(child => {
+                        if (child && child.destroy) {
+                            child.destroy();
+                        }
+                    });
+                    card.infoText.destroy(true);
+                } else if (card.infoText.destroy) {
+                    card.infoText.destroy();
+                }
+                card.infoText = null;
+            }
+        });
+
+        this.boardCards = [];
+
+        console.log('CardSystem cleaned up');
     }
 }

--- a/gameState.js
+++ b/gameState.js
@@ -13,10 +13,14 @@ export class GameState {
         this.playerEffects = [];
         this.actionsLeft = 15;
         this.maxActions = 15;
-        this.currentFloor = 1;
+        this.currentFloor = 1;  // 1-based: User-facing floor number (1, 2, 3...)
         this.equippedArmor = null;
         this.equippedWeapon = null;
-        this.inventory = new Array(5).fill(null);
+        this.bonusInventorySlots = 0; // For Bottomless Bag
+
+        const baseSlots = 5;
+        const totalSlots = baseSlots + this.bonusInventorySlots;
+        this.inventory = new Array(totalSlots).fill(null);
 
         // Room/route tracking
         this.roomType = 'COMBAT';
@@ -33,7 +37,6 @@ export class GameState {
 
         // Amulet-related properties
         this.firstActionUsed = false; // For Speed Boots
-        this.bonusInventorySlots = 0; // For Bottomless Bag
         this.baseMaxHealth = 50; // Store base max health for cursed amulets
         this.bottomlessBagApplied = false;
 
@@ -65,17 +68,17 @@ export class GameState {
     }
 
     nextFloor() {
-        this.currentFloor++;
-        
-        // Make sure inventory syncs from the actual inventory system
-        const gameScene = this.scene.scene.get('GameScene');
-        if (gameScene && gameScene.inventorySystem) {
-            this.inventory = [...gameScene.inventorySystem.slots]; // Create a copy
+        this.currentFloor++;  // Increment 1-based floor number
+
+        // Ensure currentFloor never drops below 1
+        if (this.currentFloor < 1) {
+            console.error('Floor number corruption detected, resetting to 1');
+            this.currentFloor = 1;
         }
-        
+
         this.blockNextAttack = false;
         this.firstActionUsed = false;
-        
+
         if (this.scene.amuletManager) {
             this.scene.amuletManager.processFloorEnd();
         }


### PR DESCRIPTION
## Summary
- use the shared `GameState.inventory` as the single source of truth for the inventory system
- remove manual inventory copies during scene wake and UI updates to prevent desyncs
- initialize the inventory array from bonus slots and simplify floor transitions
- remove a duplicate current-floor declaration in the map view scene to prevent syntax errors when opening the map
- standardize floor numbering by adding explicit conversion helpers and updating the map cursor to keep `currentFloor` 1-based while navigation remains 0-based
- add shutdown hooks for the map and game scenes plus card and inventory systems so tweens, listeners, and interactive sprites are cleaned up when scenes end

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ddc0697cdc832492ad6eeadb89ba3a