### PR TITLE
Improve scene shutdown cleanup and transitions

### DIFF
--- a/cardSystem.js
+++ b/cardSystem.js
@@ -1698,4 +1698,28 @@ export class CardSystem {
             this.scene.createFloatingText(x, y - 20, '+20 Coins +5 Crystals!', 0xffd700);
         });
     }
+
+    cleanup() {
+        try {
+            if (Array.isArray(this.boardCards)) {
+                this.boardCards.forEach(c => {
+                    const s = c?.sprite;
+                    if (s) {
+                        s.removeAllListeners?.();
+                        s.removeInteractive?.();
+                        s.destroy?.();
+                    }
+                    // any overlays / infoText
+                    if (c?.infoText) {
+                        if (c.infoText.list) c.infoText.destroy(true); else c.infoText.destroy();
+                        c.infoText = null;
+                    }
+                });
+            }
+        } catch (e) {
+            console.warn('CardSystem.cleanup error:', e);
+        } finally {
+            this.boardCards = [];
+        }
+    }
 }

--- a/inventorySystem.js
+++ b/inventorySystem.js
@@ -1750,4 +1750,40 @@ export class InventorySystem {
             }
         });
     }
+
+    cleanup() {
+        try {
+            // Remove listeners from cards & visuals
+            this.slotSprites.forEach(slot => {
+                const card = slot?.card;
+                if (card && card.removeAllListeners) {
+                    card.removeAllListeners(); // pointerover/out, drag*
+                    card.removeInteractive?.();
+                }
+                // Info text
+                const infoText = card?.getData?.('infoText');
+                if (infoText) {
+                    if (infoText.list) infoText.destroy(true); else infoText.destroy();
+                }
+
+                // Per-slot visuals
+                slot?.hoverSprite?.destroy?.();
+                slot?.shadow?.destroy?.();
+                slot?.twinkleSprite?.destroy?.();
+                slot.card?.destroy?.();
+
+                // Slot background
+                slot?.background?.destroy?.();
+            });
+
+            // Destroy UI group contents
+            this.uiGroup?.clear?.(true, true);
+
+        } catch (e) {
+            console.warn('InventorySystem.cleanup error:', e);
+        } finally {
+            this.slotSprites = [];
+            this.dragState = null;
+        }
+    }
 }

--- a/scenes/MapViewScene.js
+++ b/scenes/MapViewScene.js
@@ -376,11 +376,41 @@ export class MapViewScene extends Phaser.Scene {
 
 
   shutdown() {
-    this.events.off('wake');
-    if (this.dragArea) {
-      this.dragArea.off('dragstart');
-      this.dragArea.off('drag');
-      this.dragArea.off('dragend');
+    try {
+      // Remove our own wake listeners
+      this.events.removeAllListeners('wake');
+
+      // Drag area listeners and interactivity
+      if (this.dragArea) {
+        this.dragArea.removeAllListeners(); // dragstart/drag/dragend
+        this.dragArea.removeInteractive();
+        this.dragArea.destroy();
+        this.dragArea = null;
+      }
+
+      // Node sprites (pointer events)
+      if (Array.isArray(this.nodeSprites)) {
+        this.nodeSprites.forEach(s => {
+          if (!s) return;
+          s.removeAllListeners?.();
+          s.removeInteractive?.();
+          s.destroy?.();
+        });
+        this.nodeSprites = [];
+      }
+
+      // Graphics/containers
+      if (this.linkGfx) { this.linkGfx.destroy(); this.linkGfx = null; }
+      if (this.mapContainer) { this.mapContainer.destroy(true); this.mapContainer = null; }
+
+      // Kill scene tweens
+      if (this.tweens) this.tweens.killAll();
+
+      // Clear tooltip helpers if you keep closures
+      this.hideTooltip = null;
+
+    } catch (e) {
+      console.warn('MapViewScene.shutdown error:', e);
     }
   }
 }


### PR DESCRIPTION
## Summary
- register a one-time shutdown handler in GameScene and perform resilient cleanup of inputs, tweens, and subsystems
- add cleanup methods for InventorySystem and CardSystem so the scene shutdown can dispose their sprites and listeners safely
- harden MapViewScene.shutdown and update the GameScene -> map transition to stop the scene before waking or starting the map

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68df30e8ca1c8324a6308668ba50b194