### PR TITLE
Test Site: replay any story on demand

### DIFF
--- a/src/config/gameConfig.js
+++ b/src/config/gameConfig.js
@@ -10,6 +10,7 @@ import { PauseMenuScene } from '../scenes/PauseMenuScene.js';
 import { EventScene } from '../scenes/EventScene.js';
 import { TreasureScene } from '../scenes/TreasureScene.js';
 import { SandboxHubScene } from '../scenes/SandboxHubScene.js';
+import { SandboxStoryScene } from '../scenes/SandboxStoryScene.js';
 import { CharacterSelectScene } from '../scenes/CharacterSelectScene.js';
 import { TalentTreeScene } from '../scenes/TalentTreeScene.js';
 import { ArmorerPickScene } from '../scenes/ArmorerPickScene.js';
@@ -45,6 +46,7 @@ export function createGameConfig(Phaser) {
       EventScene,
       TreasureScene,
       SandboxHubScene,
+      SandboxStoryScene,
       CharacterSelectScene,
       TalentTreeScene,
       ArmorerPickScene,

--- a/src/sandbox/SandboxMode.js
+++ b/src/sandbox/SandboxMode.js
@@ -1,6 +1,9 @@
-// Test-polygon helpers: pick any encounter from a hub, then return there when done.
+// Test Site helpers: pick any encounter from a hub, then return there when done.
+
+import { EVENTS } from '../content/events/index.js';
 
 export const SANDBOX_HUB_KEY = 'SandboxHubScene';
+export const SANDBOX_STORY_KEY = 'SandboxStoryScene';
 
 export const SANDBOX_ENCOUNTERS = [
   { id: 'COMBAT', label: 'Combat', kind: 'combat' },
@@ -11,7 +14,7 @@ export const SANDBOX_ENCOUNTERS = [
   { id: 'RARE_SHOP', label: 'Rare Shop', kind: 'station', sceneKey: 'RareShopScene' },
   { id: 'REST', label: 'Rest', kind: 'station', sceneKey: 'RestScene' },
   { id: 'ANVIL', label: 'Anvil', kind: 'station', sceneKey: 'AnvilScene' },
-  { id: 'EVENT', label: 'Event', kind: 'station', sceneKey: 'EventScene' },
+  { id: 'EVENT', label: 'Event (random)', kind: 'station', sceneKey: 'EventScene' },
   { id: 'TREASURE', label: 'Treasure', kind: 'station', sceneKey: 'TreasureScene', rewardMode: 'treasure' },
   { id: 'TREASURE_GOOD', label: 'Treasure (Good)', kind: 'station', sceneKey: 'TreasureScene', rewardMode: 'good' },
   { id: 'TREASURE_ELITE', label: 'Elite Chest', kind: 'station', sceneKey: 'TreasureScene', rewardMode: 'elite' },
@@ -43,6 +46,7 @@ const SCENE_KEYS_TO_STOP = [
   'EventScene',
   'PauseMenuScene',
   SANDBOX_HUB_KEY,
+  SANDBOX_STORY_KEY,
 ];
 
 export function isSandboxMode(ref) {
@@ -55,6 +59,89 @@ export function isSandboxMode(ref) {
 
 export function getSandboxEncounter(id) {
   return SANDBOX_ENCOUNTERS.find((entry) => entry.id === id) || null;
+}
+
+// Every story, straight from the content pack, so a newly written event shows
+// up in the Test Site without anyone remembering to register it twice.
+export function getSandboxStories() {
+  return EVENTS.map((event) => ({
+    id: event.id,
+    label: event.title || event.id,
+  }));
+}
+
+// The Test Site forces a story regardless of what has been seen, but forcing
+// alone is not always enough: several events only have anything to show once
+// their prerequisites exist. Without this, opening the Goblin Engineer from the
+// menu would render a room where every choice is hidden by its condition.
+//
+// `story` is merged into storyRun; `grant` names inventory the event looks for.
+// Anything not listed here needs no setup — the sandbox loadout already hands
+// out unenchanted rare weapons and 999 coins, which is all most events check.
+const SANDBOX_STORY_SETUP = {
+  // Needs the cog recovered from the bird nest, or both repair choices hide.
+  goblin_engineer: {
+    story: { boxState: 'has_cog', boxHasCog: true, boxFollowing: true },
+  },
+  // Only fires with the engineer behind you and an egg still uneaten.
+  hatching_egg: {
+    story: { goblinEngineerResolved: true, chickHatched: false },
+    grant: ['egg'],
+  },
+  // The wizard is the carnival's follow-up, so the carnival must have happened.
+  brass_wizard: {
+    story: { carnivalVisited: true, carnivalHagMet: true },
+  },
+  // Offers to promote a companion that has fought beside you a while.
+  old_drill_room: {
+    grant: ['veteranCompanion'],
+  },
+};
+
+// Give the story a clean slate: nothing seen, nothing pending. This is what
+// makes a story testable more than once — the live run never consults saved
+// progress in the Test Site, so a story you finished months ago still opens.
+export function applySandboxStorySetup(gameScene, eventId) {
+  const gs = gameScene?.gameState;
+  if (!gs?.storyRun) return;
+
+  gs.sandboxEventId = eventId;
+
+  const setup = SANDBOX_STORY_SETUP[eventId];
+  if (!setup) return;
+
+  if (setup.story) Object.assign(gs.storyRun, setup.story);
+  for (const grant of setup.grant || []) {
+    grantSandboxStoryItem(gameScene, grant);
+  }
+
+  gameScene.inventorySystem?.rebuildInventorySprites?.();
+  gameScene.updateUI?.();
+}
+
+function grantSandboxStoryItem(gameScene, grant) {
+  const gs = gameScene.gameState;
+  const inv = gameScene.inventorySystem;
+  const gen = gameScene.cardSystem?.cardDataGenerator;
+  if (!inv || !gen) return;
+
+  if (grant === 'egg') {
+    const egg = gen.createEggCard?.();
+    if (egg) inv.addCard(egg);
+    return;
+  }
+
+  if (grant === 'veteranCompanion') {
+    const companion = gen.createChickCompanionCard?.();
+    if (!companion) return;
+    inv.addCard(companion);
+    // The drill room only offers companions with real service behind them:
+    // three rooms fought and not already upgraded.
+    if (!gs.companionHistory || typeof gs.companionHistory !== 'object') {
+      gs.companionHistory = {};
+    }
+    gs.companionHistory[companion.id] = { roomsFought: 3, upgraded: false };
+  }
 }
 
 export function applySandboxLoadout(gameScene, roomId) {
@@ -106,10 +193,22 @@ export function applySandboxLoadout(gameScene, roomId) {
 export function exitToSandboxHub(fromScene) {
   if (!fromScene?.scene) return;
   const manager = fromScene.scene;
+
+  // Read this before the teardown below drops the scenes holding it: a story
+  // launched from the picker returns to the picker, so testing the same story
+  // twice in a row is two clicks instead of four.
+  const gameScene = typeof manager.get === 'function' ? manager.get('GameScene') : null;
+  const storyId = fromScene.gameState?.sandboxEventId || gameScene?.gameState?.sandboxEventId || null;
+
   for (const key of SCENE_KEYS_TO_STOP) {
     try {
       if (manager.get(key)) manager.stop(key);
     } catch (_) { /* scene may already be gone */ }
+  }
+
+  if (storyId) {
+    manager.start(SANDBOX_STORY_KEY);
+    return;
   }
   manager.start(SANDBOX_HUB_KEY);
 }

--- a/src/scenes/EventScene.js
+++ b/src/scenes/EventScene.js
@@ -52,6 +52,8 @@ export class EventScene extends Phaser.Scene {
   init(data = {}) {
     this.gameState = data.gameState || {};
     this.gameScene = this.scene?.get?.('GameScene');
+    // Test Site: play exactly this story, whatever the story rules would say.
+    this.forcedEventId = data.forcedEventId || null;
     this.ensureStoryState();
     this.event = this._pickEvent();
     this.resolved = false;
@@ -60,6 +62,14 @@ export class EventScene extends Phaser.Scene {
   _pickEvent() {
     this.ensureStoryState();
     const story = this.gameState.storyRun;
+
+    // A story chosen in the Test Site opens no matter what — including ones the
+    // ?event= allow-list below never covered, and ones already played. Falling
+    // through to the normal rules would silently hand back a different story
+    // than the one that was clicked, which is worse than a thin version of it.
+    if (this.forcedEventId && getEvent(this.forcedEventId)) {
+      return this.getEventById(this.forcedEventId);
+    }
 
     const forcedId = this._getForcedEventId();
     if (forcedId && (forcedId !== 'hatching_egg' || this.canShowEggHatchingEvent())) {
@@ -559,10 +569,15 @@ export class EventScene extends Phaser.Scene {
   }
 
   _saveStoredHeroMemory() {
+    // Testing a story must not count as having lived it. Without this, opening
+    // the music box in the Test Site would mark it resolved forever and take it
+    // out of real runs — the same trap that made it untestable to begin with.
+    if (isSandboxMode(this)) return;
     saveHeroMemory(this.gameState.heroMemory);
   }
 
   _saveStoredStoryRun() {
+    if (isSandboxMode(this)) return;
     this.ensureStoryState();
     saveStoryProgress(this.gameState.storyRun);
   }

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -30,6 +30,7 @@ import { loadVolumeSettings, saveVolumeSettings } from '../audio/VolumeSettings.
 import { CombatTurnController } from '../systems/combat/CombatTurnController.js';
 import {
     applySandboxLoadout,
+    applySandboxStorySetup,
     exitToSandboxHub,
     getSandboxEncounter,
     isSandboxMode,
@@ -66,9 +67,12 @@ export class GameScene extends Phaser.Scene {
         // is identical every time.
         this.tutorialMode = Boolean(data.tutorial);
         if (this.tutorialMode) this.shouldLoadSave = false;
-        // Test polygon: forced single encounter, then back to the hub.
+        // Test Site: forced single encounter, then back to the hub.
         this.sandboxMode = Boolean(data.sandbox);
         this.sandboxRoom = data.sandboxRoom || null;
+        // A specific story picked from the Test Site, rather than whichever one
+        // the story rules would have served next.
+        this.sandboxEventId = data.sandboxEventId || null;
         if (this.sandboxMode) this.shouldLoadSave = false;
         this._transitioning = false;
         this._resultScreenShown = false;
@@ -102,7 +106,12 @@ export class GameScene extends Phaser.Scene {
             // progress so completed events don't repeat and story chains resume
             // where a past life left off. (Continues restore storyRun from the
             // run save instead, so we only seed brand-new runs.)
-            const storedStory = loadStoryProgress();
+            //
+            // The Test Site deliberately skips this. Seeding it there is exactly
+            // what made a finished story untestable: once the music box was
+            // resolved, boxState was never 'unknown' again and the event could
+            // not be reached without wiping the profile.
+            const storedStory = this.sandboxMode ? null : loadStoryProgress();
             if (storedStory) {
                 Object.assign(this.gameState.storyRun, storedStory);
                 // birdAngry / angryNestmotherRollFloor are per-run combat
@@ -291,6 +300,12 @@ export class GameScene extends Phaser.Scene {
             this.scene.sleep();
             const payload = { gameState: this.gameState };
             if (encounter.rewardMode) payload.rewardMode = encounter.rewardMode;
+            if (this.sandboxEventId) {
+                // Seed whatever this story needs before it opens — a recovered
+                // cog, an egg, a companion with service behind it.
+                applySandboxStorySetup(this, this.sandboxEventId);
+                payload.forcedEventId = this.sandboxEventId;
+            }
             this.scene.launch(encounter.sceneKey, payload);
             return;
         }
@@ -962,7 +977,7 @@ export class GameScene extends Phaser.Scene {
         }
         this._floorEndAlreadyProcessed = false;
 
-        // Test polygon: after a fight (or boss reward leave), return to the hub.
+        // Test Site: after a fight (or boss reward leave), return to the hub.
         // Elite still opens its chest first; TreasureScene exits back to the hub.
         if (this.sandboxMode) {
             const bossFloors = [15, 30, 45];

--- a/src/scenes/MainMenuScene.js
+++ b/src/scenes/MainMenuScene.js
@@ -59,7 +59,7 @@ export class MainMenuScene extends Phaser.Scene {
             newRun: this.createSpriteButton(320, 110, t(this, 'ui.menu.newRun'),   () => this.startNewGame()),
             continue: this.createSpriteButton(320, 142, t(this, 'ui.menu.continue'),  hasSavedRun ? () => this.continueGame() : null),
             tutorial: this.createSpriteButton(320, 174, 'Tutorial',                 () => this.startTutorial()),
-            testPolygon: this.createSpriteButton(320, 206, 'Test Polygon',          () => this.startTestPolygon()),
+            testSite: this.createSpriteButton(320, 206, 'Test Site',                () => this.startTestSite()),
             testOptions: this.createSpriteButton(320, 238, t(this, 'ui.menu.testOptions'), () => this.showTestOptionsMenu()),
             // Cog tucked into the top-right corner (32x32, 6px margin).
             options: this.createIconButton(618, 22, 'optionsButton', () => this.showOptionsMenu()),
@@ -557,7 +557,7 @@ export class MainMenuScene extends Phaser.Scene {
         });
     }
 
-    startTestPolygon() {
+    startTestSite() {
         this.fadeOutMenuMusic();
         this.cameras.main.fadeOut(350, 0, 0, 0);
         this.cameras.main.once('camerafadeoutcomplete', () => {

--- a/src/scenes/SandboxHubScene.js
+++ b/src/scenes/SandboxHubScene.js
@@ -1,7 +1,7 @@
 // Encounter sandbox hub — pick any room type, play it, return here.
 import { SoundHelper } from '../audio/SoundHelper.js';
 import { MusicManager } from '../audio/MusicManager.js';
-import { SANDBOX_ENCOUNTERS } from '../sandbox/SandboxMode.js';
+import { SANDBOX_ENCOUNTERS, SANDBOX_STORY_KEY } from '../sandbox/SandboxMode.js';
 
 export class SandboxHubScene extends Phaser.Scene {
   constructor() {
@@ -17,7 +17,7 @@ export class SandboxHubScene extends Phaser.Scene {
 
     this.add.rectangle(320, 180, 640, 360, 0x000000, 0.45);
 
-    this.add.text(320, 22, 'Test Polygon', {
+    this.add.text(320, 22, 'Test Site', {
       fontSize: '22px',
       fill: '#e6edf3',
       fontFamily: '"HoMM Pixel", Arial, sans-serif',
@@ -42,6 +42,16 @@ export class SandboxHubScene extends Phaser.Scene {
       const y = startY + row * gapY;
       this.createEncounterButton(x, y, entry.label, () => this.launchEncounter(entry.id));
     });
+
+    // "Event" above rolls whatever the story rules would serve next. This picks
+    // a specific one instead, ignoring whether it has already been played.
+    const rows = Math.ceil(SANDBOX_ENCOUNTERS.length / cols);
+    this.createEncounterButton(320, startY + rows * gapY + 8, 'Pick a Story...', () => {
+      this.cameras.main.fadeOut(200, 0, 0, 0);
+      this.cameras.main.once('camerafadeoutcomplete', () => {
+        this.scene.start(SANDBOX_STORY_KEY);
+      });
+    }, 180);
 
     this.createEncounterButton(320, 330, 'Back to Main Menu', () => {
       MusicManager.stopIfPlaying(this, 'menu_music', 300);

--- a/src/scenes/SandboxStoryScene.js
+++ b/src/scenes/SandboxStoryScene.js
@@ -1,0 +1,104 @@
+// Story picker for the Test Site — play any event on demand.
+//
+// The dungeon normally shows each story once and then remembers it forever
+// (see content/story/StoryProgress.js), which makes a finished story
+// untestable without wiping progress. Everything launched from here ignores
+// that saved progress and never writes to it, so a story can be replayed as
+// many times as it takes to get it right.
+import { SoundHelper } from '../audio/SoundHelper.js';
+import { MusicManager } from '../audio/MusicManager.js';
+import { SANDBOX_HUB_KEY, getSandboxStories } from '../sandbox/SandboxMode.js';
+
+export class SandboxStoryScene extends Phaser.Scene {
+  constructor() {
+    super({ key: 'SandboxStoryScene' });
+  }
+
+  create() {
+    if (this.textures.exists('mainBG')) {
+      this.add.image(320, 180, 'mainBG');
+    } else {
+      this.add.rectangle(320, 180, 640, 360, 0x1a1a1a);
+    }
+
+    this.add.rectangle(320, 180, 640, 360, 0x000000, 0.45);
+
+    this.add.text(320, 18, 'Test Site — Stories', {
+      fontSize: '20px',
+      fill: '#e6edf3',
+      fontFamily: '"HoMM Pixel", Arial, sans-serif',
+    }).setOrigin(0.5);
+
+    this.add.text(320, 38, 'Any story, already played or not. Progress is not saved.', {
+      fontSize: '10px',
+      fill: '#8b949e',
+      fontFamily: '"HoMM Pixel", Arial, sans-serif',
+    }).setOrigin(0.5);
+
+    // Two columns: the roster is ~17 stories and still has to clear the Back
+    // button at the bottom of a 360px-tall screen.
+    const stories = getSandboxStories();
+    const cols = 2;
+    const startX = 168;
+    const startY = 62;
+    const gapX = 304;
+    const gapY = 24;
+    const perCol = Math.ceil(stories.length / cols);
+
+    stories.forEach((story, i) => {
+      const col = Math.floor(i / perCol);
+      const row = i % perCol;
+      this.createStoryButton(
+        startX + col * gapX,
+        startY + row * gapY,
+        story.label,
+        () => this.launchStory(story.id),
+      );
+    });
+
+    this.createStoryButton(320, 338, 'Back to Test Site', () => {
+      this.cameras.main.fadeOut(200, 0, 0, 0);
+      this.cameras.main.once('camerafadeoutcomplete', () => {
+        this.scene.start(SANDBOX_HUB_KEY);
+      });
+    }, 180);
+
+    MusicManager.play(this, 'menu_music', 0.45, 600);
+  }
+
+  createStoryButton(x, y, label, onClick, width = 280) {
+    const bg = this.add.rectangle(x, y, width, 20, 0x2c1810, 0.92)
+      .setStrokeStyle(1, 0x8b6914)
+      .setInteractive({ useHandCursor: true });
+    const text = this.add.text(x, y, label, {
+      fontSize: '11px',
+      fill: '#e6edf3',
+      fontFamily: '"HoMM Pixel", Arial, sans-serif',
+    }).setOrigin(0.5);
+
+    bg.on('pointerover', () => {
+      SoundHelper.playVariant(this, 'hover_button', 0.35);
+      bg.setFillStyle(0x3d2418, 0.95);
+      bg.setStrokeStyle(1, 0xd4a017);
+    });
+    bg.on('pointerout', () => {
+      bg.setFillStyle(0x2c1810, 0.92);
+      bg.setStrokeStyle(1, 0x8b6914);
+    });
+    bg.on('pointerdown', () => onClick?.());
+
+    return { bg, text };
+  }
+
+  launchStory(eventId) {
+    MusicManager.stopIfPlaying(this, 'menu_music', 250);
+    this.cameras.main.fadeOut(280, 0, 0, 0);
+    this.cameras.main.once('camerafadeoutcomplete', () => {
+      this.scene.start('GameScene', {
+        sandbox: true,
+        sandboxRoom: 'EVENT',
+        sandboxEventId: eventId,
+      });
+    });
+  }
+}

--- a/src/ui/RunResultOverlay.js
+++ b/src/ui/RunResultOverlay.js
@@ -208,7 +208,7 @@ export function gameWon(scene) {
 
     // Victory ends the run: clear the saved run so it can't be "continued",
     // then return to the main menu instead of dropping straight into a new game.
-    addResultButton(scene, 320, 336, scene.sandboxMode ? 'Test Polygon' : 'Main Menu', () => {
+    addResultButton(scene, 320, 336, scene.sandboxMode ? 'Test Site' : 'Main Menu', () => {
         if (!scene.sandboxMode) scene.saveManager?.clearCurrentRun();
         scene.leaveSandboxOrMenu();
     }, resultDepth + 4);


### PR DESCRIPTION
Renames the main-menu **Test Polygon** button to **Test Site**, and makes it
able to open any story regardless of whether it has already been played.

## The problem

Stories are shown once and then remembered across deaths via
`content/story/StoryProgress.js`. Some are gated on state that only exists
before you have played them — the broken music box only opens while
`boxState === 'unknown'` — so once played, the only way to test one again
was to wipe the profile.

## What changed

A **Pick a Story...** button in the Test Site opens a list of every event in
the content pack. Choosing one forces it directly, bypassing the seen-checks,
the pending-event chain, and the `?event=` allow-list that previously had to
be hand-edited for each new story.

Two things make a story genuinely replayable rather than just reachable:

- the Test Site no longer seeds `storyRun` from saved progress, so what has
  already been played does not gate what can open
- it no longer writes `storyRun` or `heroMemory` back to localStorage, so
  testing a story does not consume it for real runs

`SANDBOX_STORY_SETUP` seeds prerequisites for the few stories that need them
(the engineer needs the cog; the egg needs the engineer resolved and an egg
in the bag; the drill room needs a companion with three rooms behind it).
Everything else runs on the existing sandbox loadout. Finishing a story
returns to the picker rather than the hub, so re-testing one is two clicks.

The list is read from the event registry, so a newly written story shows up
without being registered a second time.

## Testing

`node --check` passes on all eight touched files, and the module graph loads
under Node with all 17 stories resolving to their titles — this catches the
import cycle risk from `SandboxMode.js` now importing the event registry.
Layout maths for the picker were checked against the 640x360 viewport.

Not play-tested — Taya verifies gameplay directly.

## Note

Independent of #25; that branch still has Mirror Shield, this one does not
touch it, so the two can merge in either order.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)