### PR TITLE
Show loading progress instead of a blank brown screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,9 @@
         body {
             margin: 0;
             padding: 0;
-            background: #1a1a1a;
+            /* Matches the Phaser canvas colour so handing over to the game's
+               own loading bar is not a visible flash of a different screen. */
+            background: #2c1810;
             font-family: "HoMM Pixel", Arial, Helvetica, sans-serif;
             overflow: hidden;
         }
@@ -37,10 +39,78 @@
             image-rendering: pixelated;
             image-rendering: crisp-edges;
         }
+
+        /* Covers the stretch before Phaser exists: ~1.2MB of engine, the module
+           graph, and main.js's font wait. Phaser cannot draw during any of it,
+           so without this the player stares at an empty brown page and cannot
+           tell a slow download from a hang. */
+        #boot-loader {
+            position: fixed;
+            inset: 0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 14px;
+            background: #2c1810;
+            color: #e6edf3;
+            z-index: 10;
+        }
+        #boot-loader .boot-title {
+            font-size: 20px;
+            letter-spacing: 1px;
+        }
+        #boot-loader .boot-track {
+            width: 264px;
+            height: 16px;
+            border: 1px solid #8b6914;
+            background: rgba(0, 0, 0, 0.45);
+            overflow: hidden;
+        }
+        /* Indeterminate on purpose: nothing here knows the real download size,
+           and a fake percentage that jumps to 100% and waits is worse than an
+           honest "something is still happening". */
+        #boot-loader .boot-track::after {
+            content: "";
+            display: block;
+            width: 40%;
+            height: 100%;
+            background: #d4a017;
+            animation: boot-sweep 1.1s ease-in-out infinite;
+        }
+        #boot-loader .boot-status {
+            font-size: 11px;
+            color: #8b949e;
+        }
+        @keyframes boot-sweep {
+            0%   { transform: translateX(-100%); }
+            100% { transform: translateX(250%); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+            #boot-loader .boot-track::after { animation-duration: 3s; }
+        }
     </style>
 </head>
 <body>
+    <div id="boot-loader">
+        <div class="boot-title">Dungeon Card Crawler</div>
+        <div class="boot-track"></div>
+        <div class="boot-status">Starting up...</div>
+    </div>
     <div id="phaser-game-container"></div>
-    <script type="module" src="src/main.js?v=20260722-talents4"></script>
+    <script>
+        // If the engine or the module graph never arrives, main.js never runs
+        // and nothing below ever updates this screen. Say something after a
+        // while rather than sweeping a bar forever with no explanation.
+        setTimeout(function () {
+            var status = document.querySelector('#boot-loader .boot-status');
+            if (status) status.textContent = 'Still loading - large download, please wait...';
+        }, 8000);
+        setTimeout(function () {
+            var status = document.querySelector('#boot-loader .boot-status');
+            if (status) status.textContent = 'Still loading - try refreshing if this does not finish.';
+        }, 30000);
+    </script>
+    <script type="module" src="src/main.js?v=20260728-loading"></script>
 </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -19,3 +19,16 @@ try {
 }
 
 window.__game = new Phaser.Game(config);
+
+// Hand over to PreloadScene's own progress bar. Waiting for 'ready' rather than
+// removing it immediately avoids a flash of bare page between the two loading
+// screens.
+const bootLoader = document.getElementById('boot-loader');
+if (bootLoader) {
+  const removeBootLoader = () => bootLoader.remove();
+  window.__game.events.once('ready', removeBootLoader);
+  // Never let this overlay outlive the boot: if 'ready' already fired before
+  // the listener attached, or does not fire at all, the alternative is an
+  // opaque div sitting on top of a perfectly working game forever.
+  setTimeout(removeBootLoader, 5000);
+}

--- a/src/scenes/PreloadScene.js
+++ b/src/scenes/PreloadScene.js
@@ -6,6 +6,11 @@ export class PreloadScene extends Phaser.Scene {
     }
 
     preload() {
+        // Draw this before queueing anything: the manifest is ~19MB, most of it
+        // audio, and on a cold itch.io load that is several seconds of blank
+        // brown canvas that players read as a hang.
+        this.createLoadingUI();
+
         // Append a timestamp to every asset URL so Phaser never serves a
         // stale texture from its internal cache during development.
         // Remove queryURL before shipping (or it bloats itch.io logs).
@@ -22,6 +27,83 @@ export class PreloadScene extends Phaser.Scene {
         this.load.bitmapFont = (key, textureURL, xmlURL, ...rest) => _origBitmap(key, textureURL + v, xmlURL + v, ...rest);
 
         loadAssetManifest(this.load);
+    }
+
+    // Loading screen. Deliberately built from rectangles and canvas text only:
+    // this runs before a single asset exists, so it cannot use the game's
+    // sprites, and before installCrispTextFactory(), so it cannot use the
+    // bitmap fonts either.
+    createLoadingUI() {
+        const cx = 320;
+        const cy = 180;
+        const barWidth = 260;
+        const barHeight = 12;
+        const font = '"HoMM Pixel", Arial, sans-serif';
+
+        this.add.text(cx, cy - 44, 'Dungeon Card Crawler', {
+            fontSize: '18px',
+            fill: '#e6edf3',
+            fontFamily: font,
+        }).setOrigin(0.5);
+
+        this.add.rectangle(cx, cy, barWidth + 4, barHeight + 4, 0x000000, 0.45)
+            .setStrokeStyle(1, 0x8b6914);
+
+        // Grown from the left edge rather than scaled, so it stays pixel-crisp.
+        const fill = this.add
+            .rectangle(cx - barWidth / 2, cy, 1, barHeight, 0xd4a017)
+            .setOrigin(0, 0.5);
+
+        const percentText = this.add.text(cx, cy + 20, '0%', {
+            fontSize: '12px',
+            fill: '#d4a017',
+            fontFamily: font,
+        }).setOrigin(0.5);
+
+        const statusText = this.add.text(cx, cy + 38, 'Loading...', {
+            fontSize: '10px',
+            fill: '#8b949e',
+            fontFamily: font,
+        }).setOrigin(0.5);
+
+        // A percentage that sits still on one slow file looks identical to a
+        // freeze. This pulse is driven by the render loop, so as long as it is
+        // breathing the game is alive and only the download is slow.
+        this.tweens.add({
+            targets: statusText,
+            alpha: 0.3,
+            duration: 650,
+            yoyo: true,
+            repeat: -1,
+            ease: 'Sine.easeInOut',
+        });
+
+        let failed = 0;
+        const failureText = this.add.text(cx, cy + 54, '', {
+            fontSize: '9px',
+            fill: '#d98c8c',
+            fontFamily: font,
+        }).setOrigin(0.5);
+
+        this.load.on('progress', (value) => {
+            fill.width = Math.max(1, Math.round(barWidth * value));
+            percentText.setText(`${Math.round(value * 100)}%`);
+        });
+
+        // itch.io has served 403s for individual files before (see the note in
+        // index.html). Phaser carries on regardless, which turns a broken asset
+        // into a mystery crash later — so say so here, while it is still cheap
+        // to notice.
+        this.load.on('loaderror', () => {
+            failed += 1;
+            failureText.setText(`${failed} file${failed === 1 ? '' : 's'} failed to load`);
+        });
+
+        this.load.on('complete', () => {
+            fill.width = barWidth;
+            percentText.setText('100%');
+            statusText.setText('Ready');
+        });
     }
 
     create() {


### PR DESCRIPTION
Clicking **Run game** on itch dropped players onto an empty brown canvas with
no sign of life. There is a lot to wait for — **279 files, ~19MB**, most of it
the 104 audio clips — and nothing on screen distinguished that from a hang.

## Two screens, because one bar cannot cover both phases

**Before Phaser exists** (1.2MB of engine, the ES module graph, and `main.js`'s
font wait) nothing can be drawn at all. `index.html` now shows a boot loader
immediately. It is an indeterminate sweep on purpose: nothing at that point
knows the real download size, and a fake percentage that parks at 100% and
waits is worse than an honest "still working". It is background-matched to the
canvas so the handover is not a visible flash, and `main.js` removes it on
Phaser's `ready`.

**During the manifest load**, `PreloadScene` draws a real progress bar with a
live percentage, built from rectangles and canvas text since it runs before any
asset or bitmap font exists.

## Two details aimed at the actual complaint

Telling *slow* from *frozen* was the real ask, so:

- the status line pulses off the render loop — a percentage sitting still on one
  large file is still visibly alive
- failed files are counted on screen. itch has served 403s for individual assets
  before (there is a note about it in `index.html`), and Phaser otherwise carries
  on quietly until something breaks much later with no clue why

There are also two escalating messages at 8s and 30s from a plain inline script,
so if the engine never arrives at all — meaning `main.js` never runs — the
screen still explains itself instead of sweeping forever.

## Testing

Verified in a browser against the real server:

- the bar tracks genuine progress — 30px of 260 at 11%, gold fill, left-anchored
- `boot-loader` is removed via `ready`, not the timeout: `ready` fires ~9ms after
  game creation on Phaser 3.70, confirmed with a throwaway game instance, so the
  5s fallback really is only a safety net against it having already fired
- no console errors, 0 load failures across 279 files

Could not drive a load through to 100% in the harness — a hidden tab gets
throttled and pauses the loader — so the finished state and the pulse animation
are unverified visually.

## Note

Independent of #25 and #26; different files, any merge order works.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)